### PR TITLE
Added x-forwarded-proto support

### DIFF
--- a/lib/forceDomain.js
+++ b/lib/forceDomain.js
@@ -4,7 +4,8 @@ var redirect = require('./redirect');
 
 var forceDomain = function (options) {
   return function (req, res, next) {
-    var newRoute = redirect(req.protocol, req.headers.host, req.url, options),
+    var protocol = req.headers['x-forwarded-proto'] || req.protocol;
+    var newRoute = redirect(protocol, req.headers.host, req.url, options),
         statusCode;
 
     if (!newRoute) {

--- a/test/forceDomainTests.js
+++ b/test/forceDomainTests.js
@@ -298,6 +298,100 @@ suite('forceDomain', function () {
     });
   });
 
+
+  suite('hostname and x-forwarded-proto header', function () {
+    var app = express();
+
+    app.use(forceDomain({
+      hostname: 'www.example.com',
+      protocol: 'https'
+    }));
+
+    app.get('/', function (req, res) {
+      res.sendStatus(200);
+    });
+
+    test('does not redirect on localhost.', function (done) {
+      request(app)
+        .get('/')
+        .set('host', 'localhost:3000')
+        .end(function (err, res) {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
+    test('redirects on correct host and port, but other protocol.', function (done) {
+      request(app)
+        .get('/')
+        .set('x-forwarded-proto', 'https')
+        .set('host', 'www.example.com:4000')
+        .end(function (err, res) {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(307);
+          assert.that(res.header.location).is.equalTo('https://www.example.com:4000/');
+          res.resume();
+          done();
+        });
+    });
+
+    test('redirects temporarily on correct host, but other protocol.', function (done) {
+      request(app)
+        .get('/')
+        .set('host', 'www.example.com')
+        .end(function (err, res) {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(307);
+          assert.that(res.header.location).is.equalTo('https://www.example.com/');
+          res.resume();
+          done();
+        });
+    });
+
+    test('redirects temporarily on any other host, other protocol.', function (done) {
+      request(app)
+        .get('/')
+        .set('host', 'www.thenativeweb.io')
+        .end(function (err, res) {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(307);
+          assert.that(res.header.location).is.equalTo('https://www.example.com/');
+          res.resume();
+          done();
+        });
+    });
+
+    test('redirects temporarily on any other host, same protocol.', function (done) {
+      request(app)
+        .get('/')
+        .set('x-forwarded-proto', 'https')
+        .set('host', 'www.thenativeweb.io')
+        .end(function (err, res) {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(307);
+          assert.that(res.header.location).is.equalTo('https://www.example.com/');
+          res.resume();
+          done();
+        });
+    });
+
+    test('does not redirect on correct protocol and host.', function (done) {
+      request(app)
+        .get('/')
+        .set('x-forwarded-proto', 'https')
+        .set('host', 'www.example.com')
+        .end(function (err, res) {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });  
+  });
+
+
   suite('permanent redirects', function () {
     var app = express();
 

--- a/test/forceDomainTests.js
+++ b/test/forceDomainTests.js
@@ -298,7 +298,6 @@ suite('forceDomain', function () {
     });
   });
 
-
   suite('hostname and x-forwarded-proto header', function () {
     var app = express();
 
@@ -388,9 +387,8 @@ suite('forceDomain', function () {
           res.resume();
           done();
         });
-    });  
+    });
   });
-
 
   suite('permanent redirects', function () {
     var app = express();


### PR DESCRIPTION
Hi there,

I ran into a problem with redirecting apps that are behind a loadbalancer / firewall and get the protocol passed with the x-forwarded-proto header. I've added support for the header and added some tests.