### PR TITLE
Fix #7 prevent https from being redirected to http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 # OS generated files and folders
 .DS_Store
 npm-debug.log
+
+# WebIDE
+.idea

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -12,13 +12,17 @@ var redirect = function (protocol, hostHeader, url, options) {
       route;
 
   options = _.defaults(options, {
-    protocol: 'http',
+    protocol: undefined,
     type: 'temporary'
   });
 
   hostHeaderParts = (hostHeader || '').split(':');
   hostname = hostHeaderParts[0] || '';
   port = (hostHeaderParts[1] - 0) || undefined;
+
+  if (!options.protocol){
+    options.protocol = protocol
+  }
 
   if (
     (hostname === 'localhost') ||

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -9,6 +9,7 @@ var redirect = function (protocol, hostHeader, url, options) {
       hostname,
       port,
       rewrittenRoute,
+      useProtocol,
       route;
 
   options = _.defaults(options, {
@@ -20,18 +21,20 @@ var redirect = function (protocol, hostHeader, url, options) {
   hostname = hostHeaderParts[0] || '';
   port = (hostHeaderParts[1] - 0) || undefined;
 
-  if (!options.protocol){
-    options.protocol = protocol
-  }
+    if (!options.protocol){
+        useProtocol = protocol
+    } else {
+        useProtocol = options.protocol
+    }
 
   if (
     (hostname === 'localhost') ||
-    (hostname === options.hostname && port === options.port && protocol === options.protocol)
+    (hostname === options.hostname && port === options.port && protocol === useProtocol)
   ) {
     return null;
   }
 
-  route = options.protocol + '://' + hostname + (port ? ':' + port : '') + url;
+  route = useProtocol + '://' + hostname + (port ? ':' + port : '') + url;
   rewrittenRoute = rewrite(route, options);
 
   /* eslint-disable consistent-return */


### PR DESCRIPTION
It should fix the problem with permanent 'protocol'. We just get it from functiion parameters if it wasn't defined in options instead of use 'http' by default.