### PR TITLE
exclude 192.168.x.x from redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ app.use(forceDomain({
 }));
 ```
 
-*Please note that `localhost` is always being excluded from redirection. Hence you can continue developing locally as you are used to.*
+*Please note that `localhost` and local IPs (`192.168.x.x`) are always being excluded from redirection. Hence you can continue developing locally as you are used to.*
 
 ### Using a reverse-proxy
 

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -17,6 +17,7 @@ const redirect = function (protocol, hostHeader, url, options) {
 
   if (
     (hostname === 'localhost') ||
+    (hostname.startsWith('192.168.')) ||
     (hostname === options.hostname && port === options.port && protocol === targetProtocol)
   ) {
     return null;

--- a/test/forceDomainTests.js
+++ b/test/forceDomainTests.js
@@ -34,6 +34,18 @@ suite('forceDomain', () => {
         });
     });
 
+    test('does not redirect on 192.168.x.x.', done => {
+      request(app).
+        get('/').
+        set('host', '192.168.0.1:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
     test('does not redirect on correct host.', done => {
       request(app).
         get('/').
@@ -76,6 +88,18 @@ suite('forceDomain', () => {
       request(app).
         get('/').
         set('host', 'localhost:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
+    test('does not redirect on 192.168.x.x.', done => {
+      request(app).
+        get('/').
+        set('host', '192.168.0.1:3000').
         end((err, res) => {
           assert.that(err).is.null();
           assert.that(res.statusCode).is.equalTo(200);
@@ -151,6 +175,18 @@ suite('forceDomain', () => {
       request(app).
         get('/').
         set('host', 'localhost:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
+    test('does not redirect on 192.168.x.x.', done => {
+      request(app).
+        get('/').
+        set('host', '192.168.0.1:3000').
         end((err, res) => {
           assert.that(err).is.null();
           assert.that(res.statusCode).is.equalTo(200);
@@ -261,6 +297,18 @@ suite('forceDomain', () => {
         });
     });
 
+    test('does not redirect on 192.168.x.x.', done => {
+      request(app).
+        get('/').
+        set('host', '192.168.0.1:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
     test('does not redirect on correct host and port.', done => {
       request(appHttps).
         get('/').
@@ -316,6 +364,18 @@ suite('forceDomain', () => {
       request(app).
         get('/').
         set('host', 'localhost:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
+    test('does not redirect on 192.168.x.x.', done => {
+      request(app).
+        get('/').
+        set('host', '192.168.0.1:3000').
         end((err, res) => {
           assert.that(err).is.null();
           assert.that(res.statusCode).is.equalTo(200);
@@ -408,6 +468,18 @@ suite('forceDomain', () => {
       request(app).
         get('/').
         set('host', 'localhost:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
+    test('does not redirect on 192.168.x.x.', done => {
+      request(app).
+        get('/').
+        set('host', '192.168.0.1:3000').
         end((err, res) => {
           assert.that(err).is.null();
           assert.that(res.statusCode).is.equalTo(200);

--- a/test/redirectTests.js
+++ b/test/redirectTests.js
@@ -31,6 +31,31 @@ suite('redirect', () => {
       done();
     });
 
+    test('for 192.168.x.x.', done => {
+      assert.that(redirect('http', '192.168.0.1', '/foo/bar', {
+        protocol: 'https',
+        hostname: 'www.thenativeweb.io',
+        port: 3000
+      })).is.null();
+      done();
+    });
+
+    test('for 192.168.x.x:3000.', done => {
+      assert.that(redirect('http', '192.168.0.1:3000', '/foo/bar', {
+        protocol: 'https',
+        hostname: 'www.thenativeweb.io',
+        port: 3000
+      })).is.null();
+      done();
+    });
+
+    test('for https 192.168.x.x:3000.', done => {
+      assert.that(redirect('https', '192.168.0.1:3000', '/foo/bar', {
+        hostname: 'www.thenativeweb.io'
+      })).is.null();
+      done();
+    });
+
     test('for the forced domain with the correct port.', done => {
       assert.that(redirect('http', 'www.thenativeweb.io:4000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',


### PR DESCRIPTION
Fixes #16 by excluding any IPs that start with `192.168.` from redirection. I tried to follow the existing `localhost` tests in adding tests for this. I didn't add negative tests, since the other scenarios seem to cover that. Let me know of any suggestions, I'm happy to make changes if needed.