### PR TITLE
exclude regex rule, 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ app.use(forceDomain({
 }));
 ```
 
+You can use `excludeRule` to disable redirect based on a regular expression.
+
+```javascript
+app.use(forceDomain({
+  hostname: 'www.example.com',
+  excludeRule: /[a-zA-Z0-9][a-zA-Z0-9-]+\.herokuapp\.com/i
+}));
+```
+
 *Please note that `localhost` and local IPs (`192.168.x.x`) are always being excluded from redirection. Hence you can continue developing locally as you are used to.*
 
 ### Using a reverse-proxy

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ app.use(forceDomain({
 }));
 ```
 
-*Please note that `localhost` and local IPs (`192.168.x.x`) are always being excluded from redirection. Hence you can continue developing locally as you are used to.*
+*Please note that `localhost` and local IPs (`127.0.0.1`, `192.168.x.x`) are always being excluded from redirection. Hence you can continue developing locally as you are used to.*
 
 ### Using a reverse-proxy
 

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -16,7 +16,7 @@ const redirect = function (protocol, hostHeader, url, options) {
   const targetProtocol = options.protocol ? options.protocol : protocol;
 
   if (
-    (hostname === 'localhost') ||
+    (hostname === 'localhost' || hostname === '127.0.0.1') ||
     (hostname.startsWith('192.168.')) ||
     (hostname === options.hostname && port === options.port && protocol === targetProtocol) ||
     (options.excludeRule && hostname.match(options.excludeRule))

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -18,7 +18,8 @@ const redirect = function (protocol, hostHeader, url, options) {
   if (
     (hostname === 'localhost') ||
     (hostname.startsWith('192.168.')) ||
-    (hostname === options.hostname && port === options.port && protocol === targetProtocol)
+    (hostname === options.hostname && port === options.port && protocol === targetProtocol) ||
+    (options.excludeRule && hostname.match(options.excludeRule))
   ) {
     return null;
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     {
       "name": "Hüseyin Uslu",
       "email": "shalafiraistlin@gmail.com"
+    },
+    {
+      "name": "Yegor Tokmakov",
+      "email": "yegor@tokmakov.biz"
     }
   ],
   "main": "lib/forceDomain.js",

--- a/test/forceDomainTests.js
+++ b/test/forceDomainTests.js
@@ -15,7 +15,8 @@ suite('forceDomain', () => {
     const app = express();
 
     app.use(forceDomain({
-      hostname: 'www.example.com'
+      hostname: 'www.example.com',
+      excludeRule: /[a-zA-Z0-9][a-zA-Z0-9-]+\.example2\.com/i
     }));
 
     app.get('/', (req, res) => {
@@ -56,6 +57,18 @@ suite('forceDomain', () => {
           res.resume();
           done();
         });
+    });
+
+    test('does not redirect on excluded host.', done => {
+      request(app).
+      get('/').
+      set('host', 'app.example2.com').
+      end((err, res) => {
+        assert.that(err).is.null();
+        assert.that(res.statusCode).is.equalTo(200);
+        res.resume();
+        done();
+      });
     });
 
     test('redirects permanently on any other host.', done => {

--- a/test/forceDomainTests.js
+++ b/test/forceDomainTests.js
@@ -47,6 +47,18 @@ suite('forceDomain', () => {
         });
     });
 
+    test('does not redirect on 127.0.0.1.', done => {
+      request(app).
+        get('/').
+        set('host', '127.0.0.1:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
     test('does not redirect on correct host.', done => {
       request(app).
         get('/').
@@ -113,6 +125,18 @@ suite('forceDomain', () => {
       request(app).
         get('/').
         set('host', '192.168.0.1:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
+    test('does not redirect on 127.0.0.1.', done => {
+      request(app).
+        get('/').
+        set('host', '127.0.0.1:3000').
         end((err, res) => {
           assert.that(err).is.null();
           assert.that(res.statusCode).is.equalTo(200);
@@ -200,6 +224,18 @@ suite('forceDomain', () => {
       request(app).
         get('/').
         set('host', '192.168.0.1:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
+    test('does not redirect on 127.0.0.1.', done => {
+      request(app).
+        get('/').
+        set('host', '127.0.0.1:3000').
         end((err, res) => {
           assert.that(err).is.null();
           assert.that(res.statusCode).is.equalTo(200);
@@ -322,6 +358,18 @@ suite('forceDomain', () => {
         });
     });
 
+    test('does not redirect on 127.0.0.1.', done => {
+      request(app).
+        get('/').
+        set('host', '127.0.0.1:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
     test('does not redirect on correct host and port.', done => {
       request(appHttps).
         get('/').
@@ -389,6 +437,18 @@ suite('forceDomain', () => {
       request(app).
         get('/').
         set('host', '192.168.0.1:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
+    test('does not redirect on 127.0.0.1.', done => {
+      request(app).
+        get('/').
+        set('host', '127.0.0.1:3000').
         end((err, res) => {
           assert.that(err).is.null();
           assert.that(res.statusCode).is.equalTo(200);
@@ -493,6 +553,18 @@ suite('forceDomain', () => {
       request(app).
         get('/').
         set('host', '192.168.0.1:3000').
+        end((err, res) => {
+          assert.that(err).is.null();
+          assert.that(res.statusCode).is.equalTo(200);
+          res.resume();
+          done();
+        });
+    });
+
+    test('does not redirect on 127.0.0.1.', done => {
+      request(app).
+        get('/').
+        set('host', '127.0.0.1:3000').
         end((err, res) => {
           assert.that(err).is.null();
           assert.that(res.statusCode).is.equalTo(200);

--- a/test/redirectTests.js
+++ b/test/redirectTests.js
@@ -44,6 +44,7 @@ suite('redirect', () => {
       assert.that(redirect('http', '192.168.0.1:3000', '/foo/bar', {
         protocol: 'https',
         hostname: 'www.thenativeweb.io',
+        excludeRule: /[a-zA-Z0-9][a-zA-Z0-9-]+\.example2\.com/i,
         port: 3000
       })).is.null();
       done();
@@ -52,6 +53,16 @@ suite('redirect', () => {
     test('for https 192.168.x.x:3000.', done => {
       assert.that(redirect('https', '192.168.0.1:3000', '/foo/bar', {
         hostname: 'www.thenativeweb.io'
+      })).is.null();
+      done();
+    });
+
+    test('for excluded hostname.', done => {
+      assert.that(redirect('http', 'app.example2.com', '/foo/bar', {
+        protocol: 'https',
+        hostname: 'www.thenativeweb.io',
+        excludeRule: /[a-zA-Z0-9][a-zA-Z0-9-]+\.example2\.com/i,
+        port: 4000
       })).is.null();
       done();
     });
@@ -100,6 +111,7 @@ suite('redirect', () => {
     test('for another domain with another port.', done => {
       assert.that(redirect('http', 'thenativeweb.io:3000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
+        excludeRule: /[a-zA-Z0-9][a-zA-Z0-9-]+\.example2\.com/i,
         port: 4000
       })).is.equalTo({
         type: 'permanent',
@@ -122,6 +134,7 @@ suite('redirect', () => {
     test('for another domain with the another protocol.', done => {
       assert.that(redirect('http', 'thenativeweb.io:4000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
+        excludeRule: /[a-zA-Z0-9][a-zA-Z0-9-]+\.example2\.com/i,
         protocol: 'https'
       })).is.equalTo({
         type: 'permanent',
@@ -194,6 +207,7 @@ suite('redirect', () => {
       assert.that(redirect('http', 'thenativeweb.io:4000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
         protocol: 'https',
+        excludeRule: /[a-zA-Z0-9][a-zA-Z0-9-]+\.example2\.com/i,
         type: 'temporary'
       })).is.equalTo({
         type: 'temporary',

--- a/test/redirectTests.js
+++ b/test/redirectTests.js
@@ -40,6 +40,25 @@ suite('redirect', () => {
       done();
     });
 
+    test('for 127.0.0.1.', done => {
+      assert.that(redirect('http', '127.0.0.1', '/foo/bar', {
+        protocol: 'https',
+        hostname: 'www.thenativeweb.io',
+        port: 3000
+      })).is.null();
+      done();
+    });
+
+    test('for https 127.0.0.1.', done => {
+      assert.that(redirect('https', '127.0.0.1', '/foo/bar', {
+        protocol: 'https',
+        hostname: 'www.thenativeweb.io',
+        excludeRule: /[a-zA-Z0-9][a-zA-Z0-9-]+\.example2\.com/i,
+        port: 3000
+      })).is.null();
+      done();
+    });
+
     test('for 192.168.x.x:3000.', done => {
       assert.that(redirect('http', '192.168.0.1:3000', '/foo/bar', {
         protocol: 'https',


### PR DESCRIPTION
hi

I've added support for hostname exclusion by a regular expression. 
Might be useful for heroku review apps or any other environment.

Additionally, added `127.0.0.1` to excluded IPs.

Cheers